### PR TITLE
Loglevel: lower to INFO

### DIFF
--- a/src/merge_bot/merge_bot.py
+++ b/src/merge_bot/merge_bot.py
@@ -319,7 +319,7 @@ def run(
     update_go_modules=False,
 ):
     logging.basicConfig(
-        format="%(levelname)s - %(message)s", stream=sys.stdout, level=logging.DEBUG
+        format="%(levelname)s - %(message)s", stream=sys.stdout, level=logging.INFO
     )
 
     # App credentials for accessing the destination and opening a PR


### PR DESCRIPTION
With a DEBUG loglevel, all URLs are printed to stdout, including secrets
like Slack webhooks.