### PR TITLE
Update Go to v1.17.6

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -2,7 +2,7 @@ FROM registry.access.redhat.com/ubi8/python-39
 
 USER root
 
-ENV GO_VERSION=1.16.5
+ENV GO_VERSION=1.17.6
 RUN curl -Ls https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz | \
     tar -C /usr/local -zxvf - go/bin go/pkg/linux_amd64 go/pkg/tool
 ENV PATH="/usr/local/go/bin:$PATH"


### PR DESCRIPTION
fix error:

>Unable to update go modules: Command 'go mod tidy' returned non-zero exit status 1.: go mod tidy: go.mod file indicates go 1.17, but maximum supported version is 1.16