### PR TITLE
Install all of go

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -4,7 +4,7 @@ USER root
 
 ENV GO_VERSION=1.21.6
 RUN curl -Ls https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz | \
-    tar -C /usr/local -zxvf - go/bin go/pkg/tool
+    tar -C /usr/local -zxvf -
 ENV PATH="/usr/local/go/bin:$PATH"
 
 WORKDIR /src


### PR DESCRIPTION
The `GOPROXY` configuration is now read from `GOROOT/go.env` as of go 1.21, so install all of go to get rid of the following error when trying to download modules:

    GOPROXY list is not the empty string, but contains no entries