### PR TITLE
Use `mrkdwn` section type instead of `plain_text`

### DIFF
--- a/src/merge_bot/merge_bot.py
+++ b/src/merge_bot/merge_bot.py
@@ -139,7 +139,7 @@ def message_slack(webhook_url, msg):
             "blocks": [
                 {
                     "type": "section",
-                    "text": {"type": "plain_text", "text": msg[:500], "emoji": False},
+                    "text": {"type": "mrkdwn", "text": msg[:500]},
                 }
             ]
         },


### PR DESCRIPTION
... so we can render slack's markdown.
