### PR TITLE
Bump go

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -2,7 +2,7 @@ FROM registry.access.redhat.com/ubi8/python-39
 
 USER root
 
-ENV GO_VERSION=1.21.6
+ENV GO_VERSION=1.23.2
 RUN curl -Ls https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz | \
     tar -C /usr/local -zxvf -
 ENV PATH="/usr/local/go/bin:$PATH"


### PR DESCRIPTION
This should prevent errors as seen when running to mod tidy in repos using go 1.22:

    Unable to update go modules: Command 'go mod tidy -compat=1.22' returned non-zero exit status 1.: go: downloading go1.22 (linux/amd64)
    go: download go1.22 for linux/amd64: toolchain not available