### PR TITLE
New CLI option: `--run-make` to run make and commit changes

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,6 +1,8 @@
-FROM registry.access.redhat.com/ubi8/python-39
+FROM registry.fedoraproject.org/fedora:41
 
 USER root
+
+RUN dnf update -y && dnf install -y python3-pip git make diffutils && dnf clean all
 
 ENV GO_VERSION=1.23.2
 RUN curl -Ls https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz | \
@@ -13,8 +15,5 @@ RUN python -m pip install .
 
 WORKDIR /working
 RUN rm -rf /src
-RUN chown default .
-RUN chmod 0777 .
 
-USER default
-ENTRYPOINT [ "/opt/app-root/bin/merge-bot" ]
+ENTRYPOINT [ "/usr/local/bin/merge-bot" ]

--- a/src/merge_bot/cli.py
+++ b/src/merge_bot/cli.py
@@ -168,6 +168,13 @@ def parse_cli_arguments(testing_args=None):
         required=False,
         help="When enabled, the bot will update and vendor the go modules in a separate commit",
     )
+    parser.add_argument(
+        "--run-make",
+        action="store_true",
+        default=False,
+        required=False,
+        help="When enabled, the bot will run `make merge-bot` and submit any change in a separate commit",
+    )
 
     if testing_args is not None:
         args = parser.parse_args(testing_args)

--- a/src/merge_bot/test.py
+++ b/src/merge_bot/test.py
@@ -17,6 +17,7 @@ valid_args = {
     "github-cloner-key": "/credentials/gh-cloner-key",
     "slack-webhook": "/credentials/slack-webhook",
     "update-go-modules": None,
+    "run-make": None,
 }
 
 
@@ -74,6 +75,7 @@ class test_cli(unittest.TestCase):
         self.assertEqual(args.github_cloner_key, "/credentials/gh-cloner-key")
         self.assertEqual(args.slack_webhook, "/credentials/slack-webhook")
         self.assertEqual(args.update_go_modules, True)
+        self.assertEqual(args.run_make, True)
 
     def test_invalid_branch(self):
         for branch in ("dest", "source", "merge"):


### PR DESCRIPTION
Some projects need to run custom tasks when merging with upstream, like
vendoring or code generation. Let's try to run `make merge-bot`
If the target doesn't exist we return an error.

Example on where it'll be used: https://github.com/openshift/cluster-api-provider-openstack/pull/332

This feature can be used through a new CLI option: `--run-make`.