### PR TITLE
Use code fences for formatting merge-bot errors (redux)

### DIFF
--- a/src/merge_bot/cli.py
+++ b/src/merge_bot/cli.py
@@ -16,7 +16,6 @@
 
 import argparse
 import re
-import sys
 import validators
 
 from . import merge_bot


### PR DESCRIPTION
A follow-up to #32. In that commit I missed the fact that the messages were truncated to 500 characters so we often miss the closing code fence. Rather than simply fixing that oversight, we take the opportunity to improve formatting further (with the help of [block-kit-builder][1]) and include things like code fences in our output.

[1]: https://app.slack.com/block-kit-builder/
