### PR TITLE
Migrate to ruff

### DIFF
--- a/hacking/lint
+++ b/hacking/lint
@@ -1,6 +1,7 @@
 #!/bin/sh
 
-lint_args="--check --diff"
+format_args="--check --diff"
+check_args="--diff"
 
 usage() {
     echo "Usage: $0 [-r | --reformat]"
@@ -18,9 +19,17 @@ eval set -- "$PARSED_ARGS"
 while :
 do
     case $1 in
-        -r | --reformat) lint_args=""; shift ;;
-        --) shift; break;;
+        -r | --reformat)
+            check_args="--fix --unsafe-fixes"
+            format_args=""
+            shift
+            ;;
+        --)
+            shift
+            break
+            ;;
     esac
 done
 
-black $lint_args .
+ruff check --no-cache $check_args .
+ruff format --no-cache $format_args .

--- a/requirements-hacking.txt
+++ b/requirements-hacking.txt
@@ -1,1 +1,1 @@
-black
+ruff

--- a/src/merge_bot/test.py
+++ b/src/merge_bot/test.py
@@ -5,7 +5,6 @@ from git import Repo
 from . import cli
 from . import merge_bot
 
-
 valid_args = {
     "source": "https://opendev.org/openstack/kuryr-kubernetes:master",
     "dest": "openshift/kuryr-kubernetes:master",


### PR DESCRIPTION
Black has changed and is breaking the gate. Switch to ruff which is
faster and more stable (in my experience).

Signed-off-by: Stephen Finucane <stephenfin@redhat.com>
