### PR TITLE
Fix TypeError from PyJWT 2.11+ requiring iss claim to be a string

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,8 @@ python_requires = >=3.6
 install_requires =
     cryptography
     gitpython
-    github3.py
+    github3.py~=4.0
+    PyJWT~=2.4
     validators
 
 [options.entry_points]

--- a/src/merge_bot/cli.py
+++ b/src/merge_bot/cli.py
@@ -130,10 +130,10 @@ def parse_cli_arguments(testing_args=None):
     )
     parser.add_argument(
         "--github-app-id",
-        type=int,
+        type=str,
         required=False,
         help="The app ID of the GitHub app to use.",
-        default=118774,  # shiftstack-merge-bot
+        default="118774",  # shiftstack-merge-bot
     )
     parser.add_argument(
         "--github-app-key",
@@ -143,10 +143,10 @@ def parse_cli_arguments(testing_args=None):
     )
     parser.add_argument(
         "--github-cloner-id",
-        type=int,
+        type=str,
         required=False,
         help="The app ID of the GitHub cloner app to use.",
-        default=121614,  # shiftstack-merge-bot-cloner
+        default="121614",  # shiftstack-merge-bot-cloner
     )
     parser.add_argument(
         "--github-cloner-key",


### PR DESCRIPTION
Cast gh_app_id to str() when passing to github3's login_as_app and login_as_app_installation, since PyJWT 2.11.0 now enforces that the JWT issuer (iss) claim must be a string.

Also pin github3.py and add PyJWT as an explicit dependency with version bounds to prevent future surprise breakages from unpinned transitive dependencies.